### PR TITLE
Updating ATH colorpicker link

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
 						<!--<a href="https://github.com/AllTheHaxx/allthehaxx.github.io" target="_blank">» Source of this webpage</a><br>-->
 						<a href="https://github.com/AllTheHaxx/AllTheHaxx/issues" target="_blank">» Known issues/ToDo-list</a><br>
 						<a href="https://github.com/AllTheHaxx/AllTheHaxx/commits/master" target="_blank">» Latest changes &amp; changelog</a><br>
-						<br><a href="http://ath.patison.eu/" target="_blank">» ATH-Colorpicker</a> <span style="color: #666">(by Patison, thanks!)</span>
+						<br><a href="http://patison.design/ath/" target="_blank">» ATH-Colorpicker</a> <span style="color: #666">(by Patison, thanks!)</span>
 					</blockquote>
 				</section>
 			</div>


### PR DESCRIPTION
New domain name from Patison, old one doesn't work anymore.